### PR TITLE
KeyOptions parameters encoding

### DIFF
--- a/LoveSeat/Support/KeyOptions.cs
+++ b/LoveSeat/Support/KeyOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Web;
 using LoveSeat.Interfaces;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -31,7 +32,7 @@ namespace LoveSeat
             }
             if (objects.Count == 1)
             {
-                return objects[0].ToString(Formatting.None, new IsoDateTimeConverter());
+                return HttpUtility.UrlEncode(objects[0].ToString(Formatting.None, new IsoDateTimeConverter()));
             }
             
             string result = "[";
@@ -41,7 +42,10 @@ namespace LoveSeat
                 if (!first)
                     result += ",";
                 first = false;
-                result +=  item.ToString(Formatting.None, new IsoDateTimeConverter());
+                if(item.ToString().Equals("{}"))
+                    result += item.ToString(Formatting.None, new IsoDateTimeConverter());
+                else
+                    result += HttpUtility.UrlEncode(item.ToString(Formatting.None, new IsoDateTimeConverter()));
             }
             result += "]";
             return result;

--- a/LoveSeat/ViewOptions.cs
+++ b/LoveSeat/ViewOptions.cs
@@ -48,11 +48,11 @@ namespace LoveSeat
                 result += "&key=" + HttpUtility.UrlEncode(Key.ToString());
             if ((StartKey != null) && (StartKey.Count > 0))
                 if((StartKey.Count == 1) && (EndKey.Count > 1))
-                    result += "&startkey=" + HttpUtility.UrlEncode("[" + StartKey.ToString() + "]");
+                    result += "&startkey=[" + StartKey.ToString() + "]";
                 else
-                    result += "&startkey=" + HttpUtility.UrlEncode(StartKey.ToString());
+                    result += "&startkey=" + StartKey.ToString();
             if ((EndKey != null) && (EndKey.Count > 0))
-                result += "&endkey=" + HttpUtility.UrlEncode(EndKey.ToString());
+                result += "&endkey=" + EndKey.ToString();
             if (Limit.HasValue)
                 result += "&limit=" + Limit.Value.ToString();
             if (Skip.HasValue)


### PR DESCRIPTION
Moved encoding of View url parameters from ViewOptions ToString into KeyOptions ToString. Each parameter is now encoded separately (except CouchValue.Empty) which leads to more readable ViewOptions string during debugging.
