### PR TITLE
Document.Id and Document.Rev  properties behaviour

### DIFF
--- a/LoveSeat/Document.cs
+++ b/LoveSeat/Document.cs
@@ -73,11 +73,24 @@ namespace LoveSeat
 
     public class Document : JObject, IBaseObject
     {
-        [JsonProperty("_id")]
-        public string Id { get; set; }
+        [JsonIgnore]
+        public string Id
+        {
+            get { 
+                JToken id;
+                return this.TryGetValue("_id", out id) ? id.ToString() : null;
+            } 
+            set { this["_id"] = value; }
+        }
 
-        [JsonProperty("_rev")]
-        public string Rev { get; set; }
+        [JsonIgnore]
+        public string Rev { 
+            get { 
+                JToken rev;
+                return this.TryGetValue("_rev", out rev) ? rev.ToString() : null;
+            }
+            set { this["_rev"] = value; }
+        }
 
         public string Type { get; private set; }
 


### PR DESCRIPTION
Hi,

I've faced an issue recently, Document["_id"] and Document["_rev"] stay unchanged on Document.Id and Document.Rev update. In my view it is not what you'd normally expect to see.

So, I propose to make Document.Id and Document.Rev properties use JObject's indexer with keys "_id" and "_rev" as backing fields.
