### PR TITLE
Added method AddAttachment() that takes Stream as an argument

### DIFF
--- a/LoveSeat/CouchDatabase.cs
+++ b/LoveSeat/CouchDatabase.cs
@@ -167,6 +167,7 @@ namespace LoveSeat
         /// </summary>
         /// <param name="id">id of the couch Document</param>
         /// <param name="attachment">byte[] of of the attachment.  Use File.ReadAllBytes()</param>
+        /// <param name="filename">filename of the attachment</param>
         /// <param name="contentType">Content Type must be specifed</param>	
         public CouchResponse AddAttachment(string id, byte[] attachment, string filename, string contentType)
         {
@@ -186,6 +187,31 @@ namespace LoveSeat
         {
             return
                 GetRequest(databaseBaseUri + "/" + id + "/" + filename + "?rev=" + rev).Put().ContentType(contentType).Data(attachment).GetResponse().GetJObject();
+        }
+        /// <summary>
+        /// Adds an attachment to a document.  If revision is not specified then the most recent will be fetched and used.  Warning: if you need document update conflicts to occur please use the method that specifies the revision
+        /// </summary>
+        /// <param name="id">id of the couch Document</param>
+        /// <param name="attachmentStream">Stream of the attachment.</param>
+        /// <param name="contentType">Content Type must be specifed</param>	
+        public CouchResponse AddAttachment(string id, Stream attachmentStream, string filename, string contentType)
+        {
+            var doc = GetDocument(id);
+            return AddAttachment(id, doc.Rev, attachmentStream, filename, contentType);
+        }
+        /// <summary>
+        /// Adds an attachment to the documnet.  Rev must be specified on this signature.  If you want to attach no matter what then use the method without the rev param
+        /// </summary>
+        /// <param name="id">id of the couch Document</param>
+        /// <param name="rev">revision _rev of the Couch Document</param>
+        /// <param name="attachmentStream">Stream of of the attachment.  Use File.ReadAllBytes()</param>
+        /// <param name="filename">filename of the attachment</param>
+        /// <param name="contentType">Content Type must be specifed</param>			
+        /// <returns></returns>
+        public CouchResponse AddAttachment(string id, string rev, Stream attachmentStream, string filename, string contentType)
+        {
+            return
+                GetRequest(databaseBaseUri + "/" + id + "/" + filename + "?rev=" + rev).Put().ContentType(contentType).Data(attachmentStream).GetResponse().GetJObject();
         }
 
         public Stream GetAttachmentStream(Document doc, string attachmentName)

--- a/LoveSeat/Support/CouchRequest.cs
+++ b/LoveSeat/Support/CouchRequest.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Net;
 using System.Text;
 using System.Web;
@@ -7,6 +8,7 @@ namespace LoveSeat.Support {
     public class CouchRequest {
         private const string INVALID_USERNAME_OR_PASSWORD = "reason=Name or password is incorrect";
         private const string NOT_AUTHORIZED = "reason=You are not authorized to access this db.";
+        private const int STREAM_BUFFER_SIZE = 4096;
 
         private readonly HttpWebRequest request;
         public CouchRequest(string uri)
@@ -80,6 +82,19 @@ namespace LoveSeat.Support {
         }
         public CouchRequest Delete() {
             request.Method = "DELETE";
+            return this;
+        }
+        public CouchRequest Data(Stream data)
+        {
+            using (var body = request.GetRequestStream())
+            {
+                var buffer = new byte[STREAM_BUFFER_SIZE];
+                var bytesRead = 0;
+                while (0 != (bytesRead = data.Read(buffer, 0, buffer.Length)))
+                {
+                    body.Write(buffer, 0, bytesRead);   
+                }
+            }
             return this;
         }
         public CouchRequest Data(string data) {


### PR DESCRIPTION
Hi, Martin!
I've found it inconvinient not to have such method. We have GetAttachmentStream, but no method to stream an attachment to CouchDb. 
