### PR TITLE
Another View overload in IDocumentDatabase

### DIFF
--- a/LoveSeat/Interfaces/IDocumentDatabase.cs
+++ b/LoveSeat/Interfaces/IDocumentDatabase.cs
@@ -108,6 +108,7 @@ namespace LoveSeat.Interfaces
         IListResult List(string listName, string viewName, ViewOptions options,  string designDoc);
         IListResult List(string listName, string viewName, ViewOptions options);
 
+        ViewResult View(string viewName, ViewOptions options, string designDoc);
         ViewResult View(string viewName, ViewOptions options);
         ViewResult View(string viewName);
     }


### PR DESCRIPTION
This is a tiny change to extend IDocumentDatabase to include the View(string, ViewOptions, string) overload in CouchDatabase. I'm using this in my code so cannot currently declare my variables as IDocumentDatabase,
