### PR TITLE
Add SaveDocuments to IDocumentDatabase

### DIFF
--- a/LoveSeat/Interfaces/IDocumentDatabase.cs
+++ b/LoveSeat/Interfaces/IDocumentDatabase.cs
@@ -59,6 +59,7 @@ namespace LoveSeat.Interfaces
         CouchResponse DeleteAttachment(string id, string rev, string attachmentName);
         CouchResponse DeleteAttachment(string id, string attachmentName);
         CouchResponse SaveDocument(Document document);
+        BulkDocumentResponses SaveDocuments(Documents docs, bool all_or_nothing);
 
         /// <summary>
         /// Gets the results of a view with no view parameters.  Use the overload to pass parameters


### PR DESCRIPTION
Sorry - I missed this one when adding the View overload the other day. I'm finding the bulk document API very useful for large-scale deletions by the way: orders of magnitude faster than individual deletes.
