### PR TITLE
Add Keys to IViewOptions

### DIFF
--- a/LoveSeat/Interfaces/IViewOptions.cs
+++ b/LoveSeat/Interfaces/IViewOptions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace LoveSeat.Interfaces
@@ -5,6 +6,7 @@ namespace LoveSeat.Interfaces
     public interface IViewOptions
     {
         IKeyOptions Key { get; set; }
+        IEnumerable<IKeyOptions> Keys { get; set; }
         IKeyOptions StartKey { get; set; }
         IKeyOptions EndKey { get; set; }
         int? Limit { get; set; }


### PR DESCRIPTION
When adding Keys to ViewOptions a while ago I forgot to add it to the IViewOptions interface. This one-liner fixes that oversight.

Assuming you are happy to include this change, could I request an update to the LoveSeat NuGet package afterwards please? Then I can include it as a dependency in the package I'm currently constructing. Many thanks.
