### PR TITLE
No Authorization header if username is null

### DIFF
--- a/LoveSeat/Support/CouchRequest.cs
+++ b/LoveSeat/Support/CouchRequest.cs
@@ -49,15 +49,18 @@ namespace LoveSeat.Support {
             request.Headers.Clear(); //important
 
             // Deal with Authorization Header
-            string authValue = "Basic ";
-            string userNAndPassword = username + ":" + password;
+            if (username != null) {
+                string authValue = "Basic ";
+                string userNAndPassword = username + ":" + password;
 
-            // Base64 encode
-            string b64 = System.Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(userNAndPassword));
+                // Base64 encode
+                string b64 = System.Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(userNAndPassword));
 
-            authValue = authValue + b64;
+                authValue = authValue + b64;
 
-            request.Headers.Add("Authorization", authValue);
+                request.Headers.Add("Authorization", authValue);
+            }
+
             request.Headers.Add("Accept-Charset", "utf-8");
             request.Headers.Add("Accept-Language", "en-us");
             request.Referer = uri;


### PR DESCRIPTION
CouchDb behaviour seems have changed at 1.3.1, and Basic Auth requests with empty username and password are now denied when requesting database information e.g. http://host:port/database/. This change removes the Authorization header if the username is null, preventing this error.

An alternative to this approach would be to create a new AuthenticationType.None enum element, but I'm afraid I went for the quicker change.
