### PR TITLE
Added support for mutual SSL auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 *.orig
 LoveSeat.IntegrationTest/LoveSeat.IntegrationTest.pidb
+packages/

--- a/LoveSeat.IntegrationTest/LoveSeat.IntegrationTest.csproj
+++ b/LoveSeat.IntegrationTest/LoveSeat.IntegrationTest.csproj
@@ -39,9 +39,9 @@
     <Reference Include="Moq">
       <HintPath>..\Libraries\Moq\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=3.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libraries\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.4.8.0, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -73,6 +73,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Files\martin.jpg" />

--- a/LoveSeat.IntegrationTest/packages.config
+++ b/LoveSeat.IntegrationTest/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net35" />
+</packages>

--- a/LoveSeat.Interfaces/LoveSeat.Interfaces.csproj
+++ b/LoveSeat.Interfaces/LoveSeat.Interfaces.csproj
@@ -38,10 +38,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.0.3.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libraries\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/LoveSeat.Interfaces/packages.config
+++ b/LoveSeat.Interfaces/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net35" />
+</packages>

--- a/LoveSeat.Repository/LoveSeat.Repositories.csproj
+++ b/LoveSeat.Repository/LoveSeat.Repositories.csproj
@@ -32,8 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\Libraries\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -53,6 +54,9 @@
       <Project>{AF987164-0100-4A90-A767-D473F882EA8B}</Project>
       <Name>LoveSeat</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/LoveSeat.Repository/packages.config
+++ b/LoveSeat.Repository/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net35" />
+</packages>

--- a/LoveSeat/CouchClient.cs
+++ b/LoveSeat/CouchClient.cs
@@ -6,6 +6,8 @@ using Newtonsoft.Json.Linq;
 
 namespace LoveSeat
 {
+    using LoveSeat.Interfaces;
+
     // type of authentication used in request to CouchDB
     public enum AuthenticationType
     { Basic, Cookie };
@@ -43,8 +45,8 @@ namespace LoveSeat
         /// <param name="port">The port of the CouchDB instance</param>
         /// <param name="username">The username of the CouchDB instance</param>Cou
         /// <param name="password">The password of the CouchDB instance</param>
-        public CouchClient(string host, int port, string username, string password, bool isHttps, AuthenticationType aT)
-            : base(username, password, aT)
+        public CouchClient(string host, int port, string username, string password, bool isHttps, AuthenticationType aT, IConfigWebRequest configWebRequest = null)
+            : base(username, password, aT, configWebRequest)
         {
             if (isHttps == false)
             {
@@ -119,7 +121,7 @@ namespace LoveSeat
         /// <returns></returns>
         public CouchDatabase GetDatabase(string databaseName)
         {
-            return new CouchDatabase(baseUri, databaseName, username, password, this.authType);
+            return new CouchDatabase(baseUri, databaseName, username, password, this.authType, configWebRequest);
         }
 
         /// <summary>
@@ -198,7 +200,7 @@ namespace LoveSeat
         /// <returns></returns>
         public Document GetUser(string userId)
         {
-            var db = new CouchDatabase(baseUri, "_users", username, password, this.authType);
+            var db = new CouchDatabase(baseUri, "_users", username, password, this.authType, configWebRequest);
             userId = "org.couchdb.user:" + HttpUtility.UrlEncode(userId);
             return db.GetDocument(userId);
         }

--- a/LoveSeat/CouchConfiguration.cs
+++ b/LoveSeat/CouchConfiguration.cs
@@ -4,6 +4,8 @@ using Newtonsoft.Json.Linq;
 
 namespace LoveSeat
 {
+    using LoveSeat.Interfaces;
+
     public class CouchConfiguration
     {
         public CouchConfiguration()

--- a/LoveSeat/CouchDatabase.cs
+++ b/LoveSeat/CouchDatabase.cs
@@ -17,8 +17,8 @@ namespace LoveSeat
 
         private readonly string databaseBaseUri;
         private string defaultDesignDoc = null;
-        internal CouchDatabase(string baseUri, string databaseName, string username, string password, AuthenticationType aT)
-            : base(username, password, aT)
+        internal CouchDatabase(string baseUri, string databaseName, string username, string password, AuthenticationType aT, IConfigWebRequest configWebRequest)
+            : base(username, password, aT, configWebRequest)
         {
             this.baseUri = baseUri;
             this.databaseBaseUri = baseUri + databaseName;
@@ -37,7 +37,7 @@ namespace LoveSeat
             if (jobj.Value<object>("_rev") == null)
                 jobj.Remove("_rev");
             var resp = GetRequest(databaseBaseUri + "/" + id)
-                .Put().Form()
+                .Put().Json()
                 .Data(jobj.ToString(Formatting.None))
                 .GetCouchResponse();
             return
@@ -446,7 +446,7 @@ namespace LoveSeat
             if (options != null)
                 uri += options.ToString();
             CouchRequest request = GetRequest(uri, options == null ? null : options.Etag).Get().Json();
-            if (options.isAtKeysSizeLimit)
+            if (options != null && options.isAtKeysSizeLimit)
             {
                 // Encode the keys parameter in the request body and turn it into a POST request.
                 string keys = "{\"keys\": [" + String.Join(",", options.Keys.Select(k => k.ToRawString()).ToArray()) + "]}";

--- a/LoveSeat/CouchResponseObject.cs
+++ b/LoveSeat/CouchResponseObject.cs
@@ -7,6 +7,11 @@ namespace LoveSeat
     /// </summary>
     public class CouchResponseObject : JObject
     {
+        public CouchResponseObject()
+            : base()
+        {
+        }
+
         public CouchResponseObject(JObject obj)
             : base(obj)
         {

--- a/LoveSeat/Interfaces/IConfigWebRequest.cs
+++ b/LoveSeat/Interfaces/IConfigWebRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace LoveSeat.Interfaces
+{
+    using System.Net;
+
+    public interface IConfigWebRequest
+    {
+        /// <summary>
+        /// Used to configure the web request created by LoveSeat. For example, to set things like
+        /// SSL settings.
+        /// </summary>
+        /// <param name="webRequest"></param>
+        void ConfigWebRequest(HttpWebRequest webRequest);
+    }
+}

--- a/LoveSeat/LoveSeat.csproj
+++ b/LoveSeat/LoveSeat.csproj
@@ -51,9 +51,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=3.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Libraries\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -70,6 +70,7 @@
     <Compile Include="CouchResponseObject.cs" />
     <Compile Include="Document.cs" />
     <Compile Include="CouchUser.cs" />
+    <Compile Include="Interfaces\IConfigWebRequest.cs" />
     <Compile Include="Interfaces\IDocumentDatabase.cs" />
     <Compile Include="Interfaces\IKeyOptions.cs" />
     <Compile Include="Interfaces\IListResult.cs" />
@@ -118,6 +119,9 @@
       <Project>{18833FC5-9145-451D-82D4-41A1886B0BE7}</Project>
       <Name>LoveSeat.Interfaces</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/LoveSeat/Support/CouchBase.cs
+++ b/LoveSeat/Support/CouchBase.cs
@@ -3,11 +3,16 @@ using System.Net;
 
 namespace LoveSeat.Support
 {
+    using LoveSeat.Interfaces;
+
     public abstract class CouchBase
     {
         protected readonly string username;
         protected readonly string password;
         protected readonly AuthenticationType authType;
+
+        protected readonly IConfigWebRequest configWebRequest;
+
         protected string baseUri;
         private TtlDictionary<string, Cookie> cookiestore = new TtlDictionary<string, Cookie>();
         private int? timeout;
@@ -16,11 +21,12 @@ namespace LoveSeat.Support
         {
             throw new Exception("Should not be used.");
         }
-        protected CouchBase(string username, string password, AuthenticationType aT)
+        protected CouchBase(string username, string password, AuthenticationType aT, IConfigWebRequest configWebRequest = null)
         {
             this.username = username;
             this.password = password;
             this.authType = aT;
+            this.configWebRequest = configWebRequest;
         }
         public static bool Authenticate(string baseUri, string userName, string password)
         {
@@ -76,15 +82,15 @@ namespace LoveSeat.Support
             CouchRequest request;
             if (AuthenticationType.Cookie == this.authType)
             {
-                request = new CouchRequest(uri, GetSession(), etag);
+                request = new CouchRequest(uri, GetSession(), etag, configWebRequest);
             }
             else if (AuthenticationType.Basic == this.authType) //Basic Authentication
             {
-                request = new CouchRequest(uri, username, password);
+                request = new CouchRequest(uri, username, password, configWebRequest);
             }
             else //default Cookie
             {
-                request = new CouchRequest(uri, GetSession(), etag);
+                request = new CouchRequest(uri, GetSession(), etag, configWebRequest);
             }
             if (timeout.HasValue) request.Timeout(timeout.Value);
             return request;

--- a/LoveSeat/Support/CouchRequest.cs
+++ b/LoveSeat/Support/CouchRequest.cs
@@ -6,6 +6,8 @@ using Newtonsoft.Json.Linq;
 
 namespace LoveSeat.Support
 {
+    using LoveSeat.Interfaces;
+
     /// <summary>
     /// Repersent a web request for CouchDB database.
     /// </summary>
@@ -21,13 +23,14 @@ namespace LoveSeat.Support
         {
         }
 
+
         /// <summary>
         /// Request with Cookie authentication
         /// </summary>
         /// <param name="uri"></param>
         /// <param name="authCookie"></param>
         /// <param name="eTag"></param>
-        public CouchRequest(string uri, Cookie authCookie, string eTag)
+        public CouchRequest(string uri, Cookie authCookie, string eTag, IConfigWebRequest configWebRequest = null)
         {
             request = (HttpWebRequest)WebRequest.Create(uri);
             request.Headers.Clear(); //important
@@ -42,6 +45,10 @@ namespace LoveSeat.Support
             if (authCookie != null)
                 request.Headers.Add("Cookie", "AuthSession=" + authCookie.Value);
             request.Timeout = 10000;
+            if (configWebRequest != null)
+            {
+                configWebRequest.ConfigWebRequest(request);
+            }
         }
 
         /// <summary>
@@ -50,7 +57,7 @@ namespace LoveSeat.Support
         /// <param name="uri"></param>
         /// <param name="username"></param>
         /// <param name="password"></param>
-        public CouchRequest(string uri, string username, string password)
+        public CouchRequest(string uri, string username, string password, IConfigWebRequest configWebRequest = null)
         {
 
             request = (HttpWebRequest)WebRequest.Create(uri);
@@ -75,6 +82,10 @@ namespace LoveSeat.Support
             request.ContentType = "application/json";
             request.KeepAlive = true;
             request.Timeout = 10000;
+            if (configWebRequest != null)
+            {
+                configWebRequest.ConfigWebRequest(request);    
+            }
         }
 
 

--- a/LoveSeat/Support/CouchResponse.cs
+++ b/LoveSeat/Support/CouchResponse.cs
@@ -35,7 +35,7 @@ namespace LoveSeat.Support
         /// <returns></returns>
         public CouchResponseObject GetJObject()
         {
-            var resp = new CouchResponseObject(JObject.Parse(responseString));
+            var resp = string.IsNullOrEmpty(responseString) ? new CouchResponseObject() : new CouchResponseObject(JObject.Parse(responseString));
             resp.StatusCode = (int)statusCode;
             return resp;
         }

--- a/LoveSeat/packages.config
+++ b/LoveSeat/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net35" />
+</packages>


### PR DESCRIPTION
This pull request is really meant to start a conversation. I'll send a separate email with details.

I added the ability to submit an object that can take a WebRequest as
an argument and then configure it. This is what I build the Thali
logic on top of. I don't love this design but it will do for the moment.

Changed to latest json.net via nuget, bug fix & .gitignore

Nuget - All the cool kids use it, so I set up the project to use nuget to
get the latest version of json.net

.gitignore - Updated to ignore packages downloaded by nuget

empty responses - In the case of certain kinds of errors the server's
response might not have a response body which causes an exception because
GetJObject requires a response body to exist. Fixed this by adding
a constructor in CouchResponseObject that takes no arguments and
teaching CouchResponse to use that constructor if the response body
has no value.
