### PR TITLE
Enables bulk document save and user creation on a Cluster

### DIFF
--- a/LoveSeat.IntegrationTest/CouchDatabaseTest.cs
+++ b/LoveSeat.IntegrationTest/CouchDatabaseTest.cs
@@ -1,0 +1,53 @@
+﻿using NUnit.Framework;
+using System;
+using System.Configuration;
+
+namespace LoveSeat.IntegrationTest
+{
+    [TestFixture]
+    public class CouchDatabaseTest
+    {
+        private CouchDatabase db;
+        private CouchClient client;
+        private const string baseDatabase = "love-seat-test-base";
+
+        private readonly string host = ConfigurationManager.AppSettings["Host"];
+        private readonly int port = int.Parse(ConfigurationManager.AppSettings["Port"]);
+        private readonly string username = ConfigurationManager.AppSettings["UserName"];
+        private readonly string password = ConfigurationManager.AppSettings["Password"];
+
+        [SetUp]
+        public void Setup()
+        {
+            client = new CouchClient(host, port, username, password, false, AuthenticationType.Cookie);
+            if (!client.HasDatabase(baseDatabase))
+            {
+                client.CreateDatabase(baseDatabase);
+            }
+
+            var uriBuilder = new UriBuilder("http", host, port, baseDatabase);
+            db = new CouchDatabase(uriBuilder.Uri);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            //delete the test database
+            if (client.HasDatabase(baseDatabase))
+            {
+                client.DeleteDatabase(baseDatabase);
+            }
+        }
+
+        [Test]
+        public void Should_Save_Multiple_Documents()
+        {
+            var pets = new Documents();
+            pets.Values.Add(new Document(@"{ ""name"": ""Santa's Little Helper"" }"));
+            pets.Values.Add(new Document(@"{ ""name"": ""Snowball V"" }"));
+            pets.Values.Add(new Document(@"{ ""name"": ""Strangles"" }"));
+
+            db.SaveDocuments(pets, true);
+        }
+    }
+}

--- a/LoveSeat.IntegrationTest/LoveSeat.IntegrationTest.csproj
+++ b/LoveSeat.IntegrationTest/LoveSeat.IntegrationTest.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CouchClientTest.cs" />
+    <Compile Include="CouchDatabaseTest.cs" />
     <Compile Include="DocUpdaterTest.cs" />
     <Compile Include="NewtonSoftTests.cs" />
     <Compile Include="PagingHelperTest.cs" />

--- a/LoveSeat/CouchClient.cs
+++ b/LoveSeat/CouchClient.cs
@@ -248,7 +248,7 @@ namespace LoveSeat
             var docResult = GetRequest(baseUri + "_users/org.couchdb.user:" + HttpUtility.UrlEncode(usernameToCreate))
                 .Put().Json().Data(user).GetCouchResponse();
 
-            if (docResult.StatusCode == HttpStatusCode.Created)
+            if (docResult.StatusCode == HttpStatusCode.Created || docResult.StatusCode == HttpStatusCode.Accepted)
             {
                 return docResult.GetJObject();
             }

--- a/LoveSeat/CouchDatabase.cs
+++ b/LoveSeat/CouchDatabase.cs
@@ -232,7 +232,7 @@ namespace LoveSeat
                 throw new System.Exception("Response returned null.");
             }
 
-            if (resp.StatusCode != HttpStatusCode.Created)
+            if (resp.StatusCode != HttpStatusCode.Created && resp.StatusCode != HttpStatusCode.Accepted)
             {
                 throw new System.Exception("Response returned with a HTTP status code of " + resp.StatusCode + " - " + resp.StatusDescription);
             }


### PR DESCRIPTION
While the [`/db/_bulk_docs` API documentation](http://docs.couchdb.org/en/stable/api/database/bulk-api.html#inserting-documents-in-bulk) refers that:
> **The return type from a bulk insertion will be 201 Created**, with the content of the returned structure indicating specific success or otherwise messages on a per-document basis.

when working with a clustered environment the actual status code returned is `202 Accepted`, which causes an exception to be thrown in `CouchDatabase` class when validating the response of the bulk docs insertion at `SaveDocuments` method:

`if (resp.StatusCode != HttpStatusCode.Created) {`
`throw new System.Exception("Response returned with a HTTP status code of " + resp.StatusCode + " - " + resp.StatusDescription);`
`}`

A similar validation is made at `CouchClient` class, when creating a user at `CreateUser` method.

The CouchDB documentation regarding this behavior is unclear, and the only mentions I've found to the return of this status code were at [`/db`](http://docs.couchdb.org/en/stable/api/database/common.html?highlight=accepted#post--db) and [`/db/doc`](http://docs.couchdb.org/en/stable/api/document/common.html?highlight=accepted#put--db-docid) API documentation, stating that it is returned when **the data was accepted but not yet stored to disk**.

I´ve added the `Accepted` status code to both validations mentioned above.